### PR TITLE
FIX: invalid variable assignment

### DIFF
--- a/modules/format-tag-message.sh
+++ b/modules/format-tag-message.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ -z "$VERSION_TAG_PLACEHOLDER" ]; then
-    VERSION_TAG_PLACEHOLDER = "%tag%"
+    VERSION_TAG_PLACEHOLDER="%tag%"
 fi
 
 MESSAGE=$(echo "$MESSAGE" | sed s/$VERSION_TAG_PLACEHOLDER/$VERSION/g)


### PR DESCRIPTION
The spaces around the equal operator cause the format-tag-message script to break (at least when using the bash):

    /home/me/projects/git-flow-hooks/modules/format-tag-message.sh: line 4: VERSION_TAG_PLACEHOLDER: command not found
    sed: -e expression #1, char 0: no previous regular expression