### PR TITLE
Use gitflow.branch.master in prevent-master-commits hook.

### DIFF
--- a/modules/prevent-master-commits.sh
+++ b/modules/prevent-master-commits.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 
 CURRENT_BRANCH=$(git symbolic-ref HEAD)
+MASTER_BRANCH=$(git config --get gitflow.branch.master)
 
-if [ "$CURRENT_BRANCH" == "refs/heads/master" ]; then
-    __print_fail "Direct commits to the master branch are not allowed."
+if [ "$CURRENT_BRANCH" == "refs/heads/$MASTER_BRANCH" ]; then
+    __print_fail "Direct commits to the $MASTER_BRANCH branch are not allowed."
     return 1
 else
     return 0


### PR DESCRIPTION
Replace hard coded `master` branch name with the value in git flow configuration key `gitflow.branch.master`.