### PR TITLE
Make sure to only use specified VERSION_PREFIX

### DIFF
--- a/modules/semverbump.sh
+++ b/modules/semverbump.sh
@@ -56,7 +56,7 @@ fi
 # read git tags
 
 VERSION_PREFIX=$(git config --get gitflow.prefix.versiontag)
-VERSION_TAG=$(git tag -l "$VERSION_PREFIX*" | grep -E "$SEMVER_FORMAT$" | $VERSION_SORT | tail -1)
+VERSION_TAG=$(git tag -l | grep -E "^$VERSION_PREFIX$SEMVER_FORMAT$" | $VERSION_SORT | tail -1)
 
 if [ ! -z "$VERSION_TAG" ]; then
     if [ ! -z "$VERSION_PREFIX" ]; then


### PR DESCRIPTION
If it happens that you have tags in your repo mixing plain semantic versioning with versions with a prefix, current line could match the wrong tag. For instance if you have tags in your repo:

```
1.5.0
v1.5.0
```
and `export VERSION_PREFIX=` you'll get tag `v1.5.0`.

This fix makes sure that the regular expression starts at the beginning of the line so making the `VERSION_PREFIX` a real filter.